### PR TITLE
Add dependency-review CI action

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -1,0 +1,12 @@
+name: Dependency Review
+
+on:
+  pull_request:
+  merge_group:
+
+jobs:
+  dependency-review:
+    uses: gravitational/shared-workflows/.github/workflows/dependency-review.yaml@main
+    permissions:
+      contents: read
+      pull-requests: write


### PR DESCRIPTION
Since CodeQL does not currently support Rust, this should be the only necessary security CI (for now).