### PR TITLE
Use Ninja to build BoringSSL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,10 @@ name: CI
 on:
   pull_request:
     branches:
-      - master
+      - teleport
   push:
     branches:
-      - master
+      - teleport
 
 env:
   RUSTFLAGS: -Dwarnings
@@ -35,6 +35,8 @@ jobs:
       - name: Get rust version
         id: rust-version
         run: echo "::set-output name=version::$(rustc --version)"
+      - name: Install Ninja
+        uses: seanmiddleditch/gha-setup-ninja@v4
       - name: Cache cargo index
         uses: actions/cache@v1
         with:
@@ -244,6 +246,8 @@ jobs:
     - name: Install Rust (rustup)
       run: rustup update stable --no-self-update && rustup default stable
       shell: bash
+    - name: Install Ninja
+      uses: seanmiddleditch/gha-setup-ninja@v4
     - name: Install Clang-12
       uses: KyleMayes/install-llvm-action@v1
       with:
@@ -305,6 +309,8 @@ jobs:
     - name: Install Rust (rustup)
       run: rustup update stable --no-self-update && rustup default stable && rustup target add ${{ matrix.target }}
       shell: bash
+    - name: Install Ninja
+      uses: seanmiddleditch/gha-setup-ninja@v4
     - name: Install Clang-12
       uses: KyleMayes/install-llvm-action@v1
       with:

--- a/boring-sys/build/main.rs
+++ b/boring-sys/build/main.rs
@@ -199,6 +199,10 @@ fn get_boringssl_cmake_config(config: &Config) -> cmake::Config {
     let src_path = get_boringssl_source_path(config);
     let mut boringssl_cmake = cmake::Config::new(src_path);
 
+    if config.features.fips {
+        boringssl_cmake.generator("Ninja");
+    }
+
     if config.host == config.target {
         return boringssl_cmake;
     }


### PR DESCRIPTION
Ninja is a required build component, as per the BoringSSL build directions.

Using Ninja will also fix this error:
> clang-12: error: no such file or directory: 'MAKE_ASM_FLAGS'

PR is mostly cribbed from cloudflare/boring#76.